### PR TITLE
Update samtools

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -27,42 +27,42 @@
                     },
                     "samtools/collatefastq": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
                         "installed_by": ["modules"]
                     },
                     "samtools/faidx": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
                         "installed_by": ["modules"]
                     },
                     "samtools/flagstat": {
                         "branch": "master",
-                        "git_sha": "570ec5bcfe19c49e16c9ca35a7a116563af6cc1c",
+                        "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
                         "installed_by": ["modules"]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
-                        "git_sha": "e662ab16e0c11f1e62983e21de9871f59371a639",
+                        "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
                         "installed_by": ["modules"]
                     },
                     "samtools/index": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
                         "installed_by": ["modules"]
                     },
                     "samtools/merge": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
                         "installed_by": ["modules"]
                     },
                     "samtools/stats": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
                         "installed_by": ["modules"]
                     },
                     "samtools/view": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "f4596fe0bdc096cf53ec4497e83defdb3a94ff62",
                         "installed_by": ["modules"]
                     }
                 }

--- a/modules/nf-core/samtools/collatefastq/environment.yml
+++ b/modules/nf-core/samtools/collatefastq/environment.yml
@@ -1,0 +1,8 @@
+name: samtools_collatefastq
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samtools=1.19.2
+  - bioconda::htslib=1.19.1

--- a/modules/nf-core/samtools/collatefastq/main.nf
+++ b/modules/nf-core/samtools/collatefastq/main.nf
@@ -2,10 +2,10 @@ process SAMTOOLS_COLLATEFASTQ {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::samtools=1.17"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(input)

--- a/modules/nf-core/samtools/collatefastq/meta.yml
+++ b/modules/nf-core/samtools/collatefastq/meta.yml
@@ -9,11 +9,8 @@ keywords:
 tools:
   - samtools:
       description: Tools for dealing with SAM, BAM and CRAM files
-
       documentation: http://www.htslib.org/doc/1.1/samtools.html
-
       licence: ["MIT"]
-
 input:
   - meta:
       type: map
@@ -69,8 +66,11 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
-
 authors:
+  - "@lescai"
+  - "@maxulysse"
+  - "@matthdsm"
+maintainers:
   - "@lescai"
   - "@maxulysse"
   - "@matthdsm"

--- a/modules/nf-core/samtools/faidx/environment.yml
+++ b/modules/nf-core/samtools/faidx/environment.yml
@@ -1,0 +1,8 @@
+name: samtools_faidx
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samtools=1.19.2
+  - bioconda::htslib=1.19.1

--- a/modules/nf-core/samtools/faidx/main.nf
+++ b/modules/nf-core/samtools/faidx/main.nf
@@ -2,18 +2,20 @@ process SAMTOOLS_FAIDX {
     tag "$fasta"
     label 'process_single'
 
-    conda "bioconda::samtools=1.17"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(fasta)
+    tuple val(meta2), path(fai)
 
     output:
-    tuple val(meta), path ("*.fai"), emit: fai
-    tuple val(meta), path ("*.gzi"), emit: gzi, optional: true
-    path "versions.yml"            , emit: versions
+    tuple val(meta), path ("*.{fa,fasta}") , emit: fa , optional: true
+    tuple val(meta), path ("*.fai")        , emit: fai, optional: true
+    tuple val(meta), path ("*.gzi")        , emit: gzi, optional: true
+    path "versions.yml"                    , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -23,8 +25,8 @@ process SAMTOOLS_FAIDX {
     """
     samtools \\
         faidx \\
-        $args \\
-        $fasta
+        $fasta \\
+        $args
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -33,8 +35,12 @@ process SAMTOOLS_FAIDX {
     """
 
     stub:
+    def match = (task.ext.args =~ /-o(?:utput)?\s(.*)\s?/).findAll()
+    def fastacmd = match[0] ? "touch ${match[0][1]}" : ''
     """
+    ${fastacmd}
     touch ${fasta}.fai
+
     cat <<-END_VERSIONS > versions.yml
 
     "${task.process}":

--- a/modules/nf-core/samtools/faidx/meta.yml
+++ b/modules/nf-core/samtools/faidx/meta.yml
@@ -3,6 +3,7 @@ description: Index FASTA file
 keywords:
   - index
   - fasta
+  - faidx
 tools:
   - samtools:
       description: |
@@ -17,12 +18,21 @@ input:
   - meta:
       type: map
       description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
+        Groovy Map containing reference information
+        e.g. [ id:'test' ]
   - fasta:
       type: file
       description: FASTA file
       pattern: "*.{fa,fasta}"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test' ]
+  - fai:
+      type: file
+      description: FASTA index file
+      pattern: "*.{fai}"
 output:
   - meta:
       type: map
@@ -42,6 +52,10 @@ output:
       description: File containing software versions
       pattern: "versions.yml"
 authors:
+  - "@drpatelh"
+  - "@ewels"
+  - "@phue"
+maintainers:
   - "@drpatelh"
   - "@ewels"
   - "@phue"

--- a/modules/nf-core/samtools/flagstat/environment.yml
+++ b/modules/nf-core/samtools/flagstat/environment.yml
@@ -1,0 +1,8 @@
+name: samtools_flagstat
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samtools=1.19.2
+  - bioconda::htslib=1.19.1

--- a/modules/nf-core/samtools/flagstat/main.nf
+++ b/modules/nf-core/samtools/flagstat/main.nf
@@ -2,10 +2,10 @@ process SAMTOOLS_FLAGSTAT {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::samtools=1.17"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/samtools/flagstat/meta.yml
+++ b/modules/nf-core/samtools/flagstat/meta.yml
@@ -47,3 +47,5 @@ output:
       pattern: "versions.yml"
 authors:
   - "@drpatelh"
+maintainers:
+  - "@drpatelh"

--- a/modules/nf-core/samtools/flagstat/tests/main.nf.test
+++ b/modules/nf-core/samtools/flagstat/tests/main.nf.test
@@ -1,0 +1,36 @@
+nextflow_process {
+
+    name "Test Process SAMTOOLS_FLAGSTAT"
+    script "../main.nf"
+    process "SAMTOOLS_FLAGSTAT"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "samtools"
+    tag "samtools/flagstat"
+
+    test("BAM") {
+
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out.flagstat).match("flagstat") },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samtools/flagstat/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/flagstat/tests/main.nf.test.snap
@@ -1,0 +1,32 @@
+{
+    "flagstat": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.flagstat:md5,4f7ffd1e6a5e85524d443209ac97d783"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:31:37.783927"
+    },
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,fd0030ce49ab3a92091ad80260226452"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:11:44.299617452"
+    }
+}

--- a/modules/nf-core/samtools/flagstat/tests/tags.yml
+++ b/modules/nf-core/samtools/flagstat/tests/tags.yml
@@ -1,0 +1,2 @@
+samtools/flagstat:
+  - modules/nf-core/samtools/flagstat/**

--- a/modules/nf-core/samtools/idxstats/environment.yml
+++ b/modules/nf-core/samtools/idxstats/environment.yml
@@ -1,0 +1,8 @@
+name: samtools_idxstats
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samtools=1.19.2
+  - bioconda::htslib=1.19.1

--- a/modules/nf-core/samtools/idxstats/main.nf
+++ b/modules/nf-core/samtools/idxstats/main.nf
@@ -2,10 +2,10 @@ process SAMTOOLS_IDXSTATS {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::samtools=1.17"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(bam), path(bai)

--- a/modules/nf-core/samtools/idxstats/meta.yml
+++ b/modules/nf-core/samtools/idxstats/meta.yml
@@ -48,3 +48,5 @@ output:
       pattern: "versions.yml"
 authors:
   - "@drpatelh"
+maintainers:
+  - "@drpatelh"

--- a/modules/nf-core/samtools/idxstats/tests/main.nf.test
+++ b/modules/nf-core/samtools/idxstats/tests/main.nf.test
@@ -1,0 +1,36 @@
+nextflow_process {
+
+    name "Test Process SAMTOOLS_IDXSTATS"
+    script "../main.nf"
+    process "SAMTOOLS_IDXSTATS"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "samtools"
+    tag "samtools/idxstats"
+
+    test("bam") {
+
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out.idxstats).match("idxstats") },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samtools/idxstats/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/idxstats/tests/main.nf.test.snap
@@ -1,0 +1,32 @@
+{
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,613dde56f108418039ffcdeeddba397a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:16:50.147462763"
+    },
+    "idxstats": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.idxstats:md5,df60a8c8d6621100d05178c93fb053a2"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:36:41.561026"
+    }
+}

--- a/modules/nf-core/samtools/idxstats/tests/tags.yml
+++ b/modules/nf-core/samtools/idxstats/tests/tags.yml
@@ -1,0 +1,2 @@
+samtools/idxstats:
+  - modules/nf-core/samtools/idxstats/**

--- a/modules/nf-core/samtools/index/environment.yml
+++ b/modules/nf-core/samtools/index/environment.yml
@@ -1,0 +1,8 @@
+name: samtools_index
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samtools=1.19.2
+  - bioconda::htslib=1.19.1

--- a/modules/nf-core/samtools/index/main.nf
+++ b/modules/nf-core/samtools/index/main.nf
@@ -2,10 +2,10 @@ process SAMTOOLS_INDEX {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::samtools=1.17"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(input)

--- a/modules/nf-core/samtools/index/meta.yml
+++ b/modules/nf-core/samtools/index/meta.yml
@@ -51,3 +51,7 @@ authors:
   - "@drpatelh"
   - "@ewels"
   - "@maxulysse"
+maintainers:
+  - "@drpatelh"
+  - "@ewels"
+  - "@maxulysse"

--- a/modules/nf-core/samtools/index/tests/csi.nextflow.config
+++ b/modules/nf-core/samtools/index/tests/csi.nextflow.config
@@ -1,0 +1,7 @@
+process {
+
+    withName: SAMTOOLS_INDEX {
+        ext.args = '-c'
+    }
+
+}

--- a/modules/nf-core/samtools/index/tests/main.nf.test
+++ b/modules/nf-core/samtools/index/tests/main.nf.test
@@ -1,0 +1,87 @@
+nextflow_process {
+
+    name "Test Process SAMTOOLS_INDEX"
+    script "../main.nf"
+    process "SAMTOOLS_INDEX"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "samtools"
+    tag "samtools/index"
+
+    test("bai") {
+
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out.bai).match("bai") },
+                { assert snapshot(process.out.versions).match("bai_versions") }
+            )
+        }
+    }
+
+    test("crai") {
+
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.recalibrated.sorted.cram', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert snapshot(process.out.crai).match("crai") },
+                { assert snapshot(process.out.versions).match("crai_versions") }
+            )
+        }
+    }
+
+    test("csi") {
+
+        config "./csi.nextflow.config"
+
+        when {
+            params {
+                outdir   = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll (
+                { assert process.success },
+                { assert path(process.out.csi.get(0).get(1)).exists() },
+                { assert snapshot(process.out.versions).match("csi_versions") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samtools/index/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/index/tests/main.nf.test.snap
@@ -1,0 +1,74 @@
+{
+    "crai_versions": {
+        "content": [
+            [
+                "versions.yml:md5,cc4370091670b64bba7c7206403ffb3e"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:12:00.324667957"
+    },
+    "csi_versions": {
+        "content": [
+            [
+                "versions.yml:md5,cc4370091670b64bba7c7206403ffb3e"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:12:07.885103162"
+    },
+    "crai": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.paired_end.recalibrated.sorted.cram.crai:md5,14bc3bd5c89cacc8f4541f9062429029"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:41:38.446424"
+    },
+    "bai": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.paired_end.sorted.bam.bai:md5,704c10dd1326482448ca3073fdebc2f4"
+                ]
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:40:46.579747"
+    },
+    "bai_versions": {
+        "content": [
+            [
+                "versions.yml:md5,cc4370091670b64bba7c7206403ffb3e"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:11:51.641425452"
+    }
+}

--- a/modules/nf-core/samtools/index/tests/tags.yml
+++ b/modules/nf-core/samtools/index/tests/tags.yml
@@ -1,0 +1,2 @@
+samtools/index:
+  - modules/nf-core/samtools/index/**

--- a/modules/nf-core/samtools/merge/environment.yml
+++ b/modules/nf-core/samtools/merge/environment.yml
@@ -1,0 +1,8 @@
+name: samtools_merge
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samtools=1.19.2
+  - bioconda::htslib=1.19.1

--- a/modules/nf-core/samtools/merge/main.nf
+++ b/modules/nf-core/samtools/merge/main.nf
@@ -2,20 +2,21 @@ process SAMTOOLS_MERGE {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::samtools=1.17"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(input_files, stageAs: "?/*")
-    path fasta
-    path fai
+    tuple val(meta2), path(fasta)
+    tuple val(meta3), path(fai)
 
     output:
     tuple val(meta), path("${prefix}.bam") , optional:true, emit: bam
     tuple val(meta), path("${prefix}.cram"), optional:true, emit: cram
     tuple val(meta), path("*.csi")         , optional:true, emit: csi
+    tuple val(meta), path("*.crai")        , optional:true, emit: crai
     path  "versions.yml"                                  , emit: versions
 
 
@@ -43,10 +44,14 @@ process SAMTOOLS_MERGE {
     """
 
     stub:
+    def args = task.ext.args   ?: ''
     prefix = task.ext.suffix ? "${meta.id}${task.ext.suffix}" : "${meta.id}"
     def file_type = input_files instanceof List ? input_files[0].getExtension() : input_files.getExtension()
+    def index_type = file_type == "bam" ? "csi" : "crai"
+    def index = args.contains("--write-index") ? "touch ${prefix}.${index_type}" : ""
     """
     touch ${prefix}.${file_type}
+    ${index}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/samtools/merge/meta.yml
+++ b/modules/nf-core/samtools/merge/meta.yml
@@ -25,13 +25,23 @@ input:
       type: file
       description: BAM/CRAM file
       pattern: "*.{bam,cram,sam}"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'genome' ]
   - fasta:
-      type: optional file
-      description: Reference file the CRAM was created with
+      type: file
+      description: Reference file the CRAM was created with (optional)
       pattern: "*.{fasta,fa}"
+  - meta3:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'genome' ]
   - fai:
-      type: optional file
-      description: Index of the reference file the CRAM was created with
+      type: file
+      description: Index of the reference file the CRAM was created with (optional)
       pattern: "*.fai"
 output:
   - meta:
@@ -55,8 +65,19 @@ output:
       type: file
       description: BAM index file (optional)
       pattern: "*.csi"
+  - crai:
+      type: file
+      description: CRAM index file (optional)
+      pattern: "*.crai"
 authors:
   - "@drpatelh"
   - "@yuukiiwa "
   - "@maxulysse"
   - "@FriederikeHanssen"
+  - "@ramprasadn"
+maintainers:
+  - "@drpatelh"
+  - "@yuukiiwa "
+  - "@maxulysse"
+  - "@FriederikeHanssen"
+  - "@ramprasadn"

--- a/modules/nf-core/samtools/merge/tests/index.config
+++ b/modules/nf-core/samtools/merge/tests/index.config
@@ -1,0 +1,3 @@
+process {
+    ext.args = "--write-index"
+}

--- a/modules/nf-core/samtools/merge/tests/main.nf.test
+++ b/modules/nf-core/samtools/merge/tests/main.nf.test
@@ -1,0 +1,137 @@
+nextflow_process {
+
+    name "Test Process SAMTOOLS_MERGE"
+    script "../main.nf"
+    process "SAMTOOLS_MERGE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "samtools"
+    tag "samtools/merge"
+
+    test("bams") {
+
+        config "./index.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.methylated.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.sorted.bam', checkIfExists: true) ]
+                ])
+                input[1] = [[],[]]
+                input[2] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.bam[0][1]).name).match("bams_bam") },
+                { assert snapshot(process.out.cram).match("bams_cram") },
+                { assert snapshot(file(process.out.csi[0][1]).name).match("bams_csi") },
+                { assert snapshot(process.out.crai).match("bams_crai") },
+                { assert snapshot(process.out.versions).match("bams_versions") }
+            )
+        }
+    }
+
+    test("crams") {
+
+        config "./index.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.recalibrated.sorted.cram', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test2.paired_end.recalibrated.sorted.cram', checkIfExists: true) ]
+                ])
+                input[1] = Channel.of([
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = Channel.of([
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.cram[0][1]).name).match("crams_cram") },
+                { assert snapshot(process.out.bam).match("crams_bam") },
+                { assert snapshot(file(process.out.crai[0][1]).name).match("crams_crai") },
+                { assert snapshot(process.out.csi).match("crams_csi") },
+                { assert snapshot(process.out.versions).match("crams_versions") }
+            )
+        }
+    }
+
+    test("bam") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.methylated.sorted.bam', checkIfExists: true) ]
+                ])
+                input[1] = [[],[]]
+                input[2] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.bam[0][1]).name).match("bam_bam") },
+                { assert snapshot(process.out.cram).match("bam_cram") },
+                { assert snapshot(process.out.crai).match("bam_crai") },
+                { assert snapshot(process.out.csi).match("bam_csi") },
+                { assert snapshot(process.out.versions).match("bam_versions") }
+            )
+        }
+    }
+
+    test("bams_stub") {
+
+        config "./index.config"
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.methylated.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.single_end.sorted.bam', checkIfExists: true) ]
+                ])
+                input[1] = [[],[]]
+                input[2] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.bam[0][1]).name).match("bams_stub_bam") },
+                { assert snapshot(process.out.cram).match("bams_stub_cram") },
+                { assert snapshot(file(process.out.csi[0][1]).name).match("bams_stub_csi") },
+                { assert snapshot(process.out.crai).match("bams_stub_crai") },
+                { assert snapshot(process.out.versions).match("bams_stub_versions") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samtools/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/merge/tests/main.nf.test.snap
@@ -1,0 +1,228 @@
+{
+    "crams_cram": {
+        "content": [
+            "test.cram"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:00.647389"
+    },
+    "bams_stub_cram": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:19.937013"
+    },
+    "bams_crai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:49:24.928616"
+    },
+    "bams_bam": {
+        "content": [
+            "test.bam"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:49:24.923289"
+    },
+    "bams_cram": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:49:24.925716"
+    },
+    "crams_csi": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:00.655959"
+    },
+    "bam_bam": {
+        "content": [
+            "test.bam"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:10.319539"
+    },
+    "bam_versions": {
+        "content": [
+            [
+                "versions.yml:md5,52c62d4712f7af00eb962d090ca32fe4"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:16:33.782637377"
+    },
+    "bams_csi": {
+        "content": [
+            "test.bam.csi"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:49:24.92719"
+    },
+    "bams_stub_csi": {
+        "content": [
+            "test.csi"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:19.940498"
+    },
+    "bam_crai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:10.328852"
+    },
+    "bams_stub_versions": {
+        "content": [
+            [
+                "versions.yml:md5,52c62d4712f7af00eb962d090ca32fe4"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:16:42.594476052"
+    },
+    "bam_cram": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:10.324219"
+    },
+    "bams_stub_bam": {
+        "content": [
+            "test.bam"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:19.933153"
+    },
+    "bams_versions": {
+        "content": [
+            [
+                "versions.yml:md5,52c62d4712f7af00eb962d090ca32fe4"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:16:04.805335656"
+    },
+    "crams_bam": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:00.650652"
+    },
+    "crams_versions": {
+        "content": [
+            [
+                "versions.yml:md5,52c62d4712f7af00eb962d090ca32fe4"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:16:25.889394689"
+    },
+    "bam_csi": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:10.33292"
+    },
+    "crams_crai": {
+        "content": [
+            "test.cram.crai"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:00.653512"
+    },
+    "bams_stub_crai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T18:50:19.943839"
+    }
+}

--- a/modules/nf-core/samtools/merge/tests/tags.yml
+++ b/modules/nf-core/samtools/merge/tests/tags.yml
@@ -1,0 +1,2 @@
+samtools/merge:
+  - "modules/nf-core/samtools/merge/**"

--- a/modules/nf-core/samtools/stats/environment.yml
+++ b/modules/nf-core/samtools/stats/environment.yml
@@ -1,0 +1,8 @@
+name: samtools_stats
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samtools=1.19.2
+  - bioconda::htslib=1.19.1

--- a/modules/nf-core/samtools/stats/main.nf
+++ b/modules/nf-core/samtools/stats/main.nf
@@ -2,14 +2,14 @@ process SAMTOOLS_STATS {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::samtools=1.17"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(input), path(input_index)
-    path fasta
+    tuple val(meta2), path(fasta)
 
     output:
     tuple val(meta), path("*.stats"), emit: stats

--- a/modules/nf-core/samtools/stats/meta.yml
+++ b/modules/nf-core/samtools/stats/meta.yml
@@ -30,9 +30,14 @@ input:
       type: file
       description: BAI/CRAI file from alignment
       pattern: "*.{bai,crai}"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'genome' ]
   - fasta:
-      type: optional file
-      description: Reference file the CRAM was created with
+      type: file
+      description: Reference file the CRAM was created with (optional)
       pattern: "*.{fasta,fa}"
 output:
   - meta:
@@ -51,3 +56,8 @@ output:
 authors:
   - "@drpatelh"
   - "@FriederikeHanssen"
+  - "@ramprasadn"
+maintainers:
+  - "@drpatelh"
+  - "@FriederikeHanssen"
+  - "@ramprasadn"

--- a/modules/nf-core/samtools/stats/tests/main.nf.test
+++ b/modules/nf-core/samtools/stats/tests/main.nf.test
@@ -1,0 +1,65 @@
+nextflow_process {
+
+    name "Test Process SAMTOOLS_STATS"
+    script "../main.nf"
+    process "SAMTOOLS_STATS"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "samtools"
+    tag "samtools/stats"
+
+    test("bam") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai', checkIfExists: true)
+                ])
+                input[1] = [[],[]]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                {assert process.success},
+                {assert snapshot(process.out).match()}
+            )
+        }
+    }
+
+    test("cram") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.recalibrated.sorted.cram', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.recalibrated.sorted.cram.crai', checkIfExists: true)
+                ])
+                input[1] = Channel.of([
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                {assert process.success},
+                {assert snapshot(process.out).match()}
+            )
+        }
+    }
+}

--- a/modules/nf-core/samtools/stats/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/stats/tests/main.nf.test.snap
@@ -1,0 +1,72 @@
+{
+    "cram": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,01812900aa4027532906c5d431114233"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,0514ceb1769b2a88843e08c1f82624a9"
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,01812900aa4027532906c5d431114233"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,0514ceb1769b2a88843e08c1f82624a9"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:15:25.562429714"
+    },
+    "bam": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,5d8681bf541199898c042bf400391d59"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,0514ceb1769b2a88843e08c1f82624a9"
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.stats:md5,5d8681bf541199898c042bf400391d59"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,0514ceb1769b2a88843e08c1f82624a9"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:15:07.857611509"
+    }
+}

--- a/modules/nf-core/samtools/stats/tests/tags.yml
+++ b/modules/nf-core/samtools/stats/tests/tags.yml
@@ -1,0 +1,2 @@
+samtools/stats:
+  - modules/nf-core/samtools/stats/**

--- a/modules/nf-core/samtools/view/environment.yml
+++ b/modules/nf-core/samtools/view/environment.yml
@@ -1,0 +1,8 @@
+name: samtools_view
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::samtools=1.19.2
+  - bioconda::htslib=1.19.1

--- a/modules/nf-core/samtools/view/main.nf
+++ b/modules/nf-core/samtools/view/main.nf
@@ -2,14 +2,14 @@ process SAMTOOLS_VIEW {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::samtools=1.17"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/samtools:1.17--h00cdaf9_0' :
-        'biocontainers/samtools:1.17--h00cdaf9_0' }"
+        'https://depot.galaxyproject.org/singularity/samtools:1.19.2--h50ea8bc_0' :
+        'biocontainers/samtools:1.19.2--h50ea8bc_0' }"
 
     input:
     tuple val(meta), path(input), path(index)
-    path fasta
+    tuple val(meta2), path(fasta)
     path qname
 
     output:
@@ -53,10 +53,19 @@ process SAMTOOLS_VIEW {
     """
 
     stub:
+    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def file_type = args.contains("--output-fmt sam") ? "sam" :
+                    args.contains("--output-fmt bam") ? "bam" :
+                    args.contains("--output-fmt cram") ? "cram" :
+                    input.getExtension()
+    if ("$input" == "${prefix}.${file_type}") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+
+    def index = args.contains("--write-index") ? "touch ${prefix}.csi" : ""
+
     """
-    touch ${prefix}.bam
-    touch ${prefix}.cram
+    touch ${prefix}.${file_type}
+    ${index}
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/samtools/view/meta.yml
+++ b/modules/nf-core/samtools/view/meta.yml
@@ -26,12 +26,17 @@ input:
       description: BAM/CRAM/SAM file
       pattern: "*.{bam,cram,sam}"
   - index:
-      type: optional file
-      description: BAM.BAI/BAM.CSI/CRAM.CRAI file
+      type: file
+      description: BAM.BAI/BAM.CSI/CRAM.CRAI file (optional)
       pattern: "*.{.bai,.csi,.crai}"
+  - meta2:
+      type: map
+      description: |
+        Groovy Map containing reference information
+        e.g. [ id:'test' ]
   - fasta:
-      type: optional file
-      description: Reference file the CRAM was created with
+      type: file
+      description: Reference file the CRAM was created with (optional)
       pattern: "*.{fasta,fa}"
   - qname:
       type: file
@@ -73,6 +78,11 @@ output:
       description: File containing software versions
       pattern: "versions.yml"
 authors:
+  - "@drpatelh"
+  - "@joseespinosa"
+  - "@FriederikeHanssen"
+  - "@priyanka-surana"
+maintainers:
   - "@drpatelh"
   - "@joseespinosa"
   - "@FriederikeHanssen"

--- a/modules/nf-core/samtools/view/tests/bam.config
+++ b/modules/nf-core/samtools/view/tests/bam.config
@@ -1,0 +1,3 @@
+process {
+    ext.args = "--output-fmt bam"
+}

--- a/modules/nf-core/samtools/view/tests/bam_index.config
+++ b/modules/nf-core/samtools/view/tests/bam_index.config
@@ -1,0 +1,3 @@
+process {
+    ext.args = "--output-fmt bam --write-index"
+}

--- a/modules/nf-core/samtools/view/tests/main.nf.test
+++ b/modules/nf-core/samtools/view/tests/main.nf.test
@@ -1,0 +1,212 @@
+nextflow_process {
+
+    name "Test Process SAMTOOLS_VIEW"
+    script "../main.nf"
+    process "SAMTOOLS_VIEW"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "samtools"
+    tag "samtools/view"
+
+    test("bam") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.bam', checkIfExists: true),
+                    []
+                ])
+                input[1] = [[],[]]
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.bam[0][1]).name).match("bam_bam") },
+                { assert snapshot(process.out.bai).match("bam_bai") },
+                { assert snapshot(process.out.crai).match("bam_crai") },
+                { assert snapshot(process.out.cram).match("bam_cram") },
+                { assert snapshot(process.out.csi).match("bam_csi") },
+                { assert snapshot(process.out.sam).match("bam_sam") },
+                { assert snapshot(process.out.versions).match("bam_versions") }
+            )
+        }
+    }
+
+    test("cram") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram.crai', checkIfExists: true)
+                ])
+                input[1] = Channel.of([
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.cram[0][1]).name).match("cram_cram") },
+                { assert snapshot(process.out.bai).match("cram_bai") },
+                { assert snapshot(process.out.bam).match("cram_bam") },
+                { assert snapshot(process.out.crai).match("cram_crai") },
+                { assert snapshot(process.out.csi).match("cram_csi") },
+                { assert snapshot(process.out.sam).match("cram_sam") },
+                { assert snapshot(process.out.versions).match("cram_versions") }
+            )
+        }
+    }
+
+    test("cram_to_bam") {
+
+        config "./bam.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
+                    []
+                ])
+                input[1] = Channel.of([
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.bam[0][1]).name).match("cram_to_bam_bam") },
+                { assert snapshot(process.out.bai).match("cram_to_bam_bai") },
+                { assert snapshot(process.out.crai).match("cram_to_bam_crai") },
+                { assert snapshot(process.out.cram).match("cram_to_bam_cram") },
+                { assert snapshot(process.out.csi).match("cram_to_bam_csi") },
+                { assert snapshot(process.out.sam).match("cram_to_bam_sam") },
+                { assert snapshot(process.out.versions).match("cram_to_bam_versions") }
+            )
+        }
+    }
+
+    test("cram_to_bam_index") {
+
+        config "./bam_index.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
+                    []
+                ])
+                input[1] = Channel.of([
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.bam[0][1]).name).match("cram_to_bam_index_bam") },
+                { assert snapshot(file(process.out.csi[0][1]).name).match("cram_to_bam_index_csi") },
+                { assert snapshot(process.out.bai).match("cram_to_bam_index_bai") },
+                { assert snapshot(process.out.crai).match("cram_to_bam_index_crai") },
+                { assert snapshot(process.out.cram).match("cram_to_bam_index_cram") },
+                { assert snapshot(process.out.sam).match("cram_to_bam_index_sam") },
+                { assert snapshot(process.out.versions).match("cram_to_bam_index_versions") }
+            )
+        }
+    }
+
+    test("cram_to_bam_index_qname") {
+
+        config "./bam_index.config"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/cram/test.paired_end.sorted.cram', checkIfExists: true),
+                    []
+                ])
+                input[1] = Channel.of([
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                ])
+                input[2] = Channel.of("testN:2817", "testN:2814").collectFile(name: "readnames.list", newLine: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.bam[0][1]).name).match("cram_to_bam_index_qname_bam") },
+                { assert snapshot(file(process.out.csi[0][1]).name).match("cram_to_bam_index_qname_csi") },
+                { assert snapshot(process.out.bai).match("cram_to_bam_index_qname_bai") },
+                { assert snapshot(process.out.crai).match("cram_to_bam_index_qname_crai") },
+                { assert snapshot(process.out.cram).match("cram_to_bam_index_qname_cram") },
+                { assert snapshot(process.out.sam).match("cram_to_bam_index_qname_sam") },
+                { assert snapshot(process.out.versions).match("cram_to_bam_index_qname_versions") }
+            )
+        }
+    }
+
+    test("bam_stub") {
+
+        options "-stub"
+        config "./bam_index.config"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.test_data['sarscov2']['illumina']['test_paired_end_bam'], checkIfExists: true),
+                    []
+                ]
+                input[1] = [[],[]]
+                input[2] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.bam[0][1]).name).match("bam_stub_bam") },
+                { assert snapshot(file(process.out.csi[0][1]).name).match("bam_stub_csi") },
+                { assert snapshot(process.out.bai).match("bam_stub_bai") },
+                { assert snapshot(process.out.crai).match("bam_stub_crai") },
+                { assert snapshot(process.out.cram).match("bam_stub_cram") },
+                { assert snapshot(process.out.sam).match("bam_stub_sam") },
+                { assert snapshot(process.out.versions).match("bam_stub_versions") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samtools/view/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/view/tests/main.nf.test.snap
@@ -1,0 +1,488 @@
+{
+    "bam_bam": {
+        "content": [
+            "test.bam"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:51.256068"
+    },
+    "cram_to_bam_index_csi": {
+        "content": [
+            "test.bam.csi"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:12.958617"
+    },
+    "bam_stub_bam": {
+        "content": [
+            "test.bam"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:32.065301"
+    },
+    "bam_bai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:51.258578"
+    },
+    "bam_stub_bai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:32.071284"
+    },
+    "bam_stub_versions": {
+        "content": [
+            [
+                "versions.yml:md5,4ea32c57d546102a1b32d9693ada7cf1"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:13:09.713353823"
+    },
+    "cram_to_bam_index_cram": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:12.972288"
+    },
+    "cram_to_bam_sam": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:04.999247"
+    },
+    "cram_to_bam_index_sam": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:12.976457"
+    },
+    "cram_crai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:56.497581"
+    },
+    "cram_csi": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:56.50038"
+    },
+    "cram_to_bam_cram": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:04.992239"
+    },
+    "cram_to_bam_index_qname_csi": {
+        "content": [
+            "test.bam.csi"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:23.325496"
+    },
+    "bam_stub_sam": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:32.079529"
+    },
+    "cram_cram": {
+        "content": [
+            "test.cram"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:56.490286"
+    },
+    "bam_csi": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:51.262882"
+    },
+    "cram_to_bam_crai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:04.989247"
+    },
+    "cram_to_bam_index_crai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:12.967681"
+    },
+    "cram_to_bam_index_qname_versions": {
+        "content": [
+            [
+                "versions.yml:md5,4ea32c57d546102a1b32d9693ada7cf1"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:13:03.935041046"
+    },
+    "cram_to_bam_bam": {
+        "content": [
+            "test.bam"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:04.982361"
+    },
+    "cram_to_bam_index_bam": {
+        "content": [
+            "test.bam"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:12.95456"
+    },
+    "cram_to_bam_index_versions": {
+        "content": [
+            [
+                "versions.yml:md5,4ea32c57d546102a1b32d9693ada7cf1"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:12:55.910685496"
+    },
+    "cram_to_bam_bai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:04.98601"
+    },
+    "cram_to_bam_versions": {
+        "content": [
+            [
+                "versions.yml:md5,4ea32c57d546102a1b32d9693ada7cf1"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:12:47.715221169"
+    },
+    "cram_bam": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:56.495512"
+    },
+    "bam_stub_cram": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:32.076908"
+    },
+    "cram_to_bam_index_qname_bai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:23.328458"
+    },
+    "cram_to_bam_index_qname_crai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:23.330789"
+    },
+    "cram_bai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:56.493129"
+    },
+    "bam_stub_crai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:32.074313"
+    },
+    "cram_to_bam_index_qname_bam": {
+        "content": [
+            "test.bam"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:23.322874"
+    },
+    "bam_versions": {
+        "content": [
+            [
+                "versions.yml:md5,4ea32c57d546102a1b32d9693ada7cf1"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:12:31.692607421"
+    },
+    "cram_to_bam_index_qname_cram": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:23.333248"
+    },
+    "bam_crai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:51.259774"
+    },
+    "bam_cram": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:51.261287"
+    },
+    "cram_to_bam_csi": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:04.995454"
+    },
+    "cram_sam": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:56.502625"
+    },
+    "cram_versions": {
+        "content": [
+            [
+                "versions.yml:md5,4ea32c57d546102a1b32d9693ada7cf1"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.01.0"
+        },
+        "timestamp": "2024-02-13T16:12:39.913411036"
+    },
+    "bam_sam": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:37:51.264651"
+    },
+    "cram_to_bam_index_bai": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:12.962863"
+    },
+    "cram_to_bam_index_qname_sam": {
+        "content": [
+            [
+                
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:23.337634"
+    },
+    "bam_stub_csi": {
+        "content": [
+            "test.csi"
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.04.3"
+        },
+        "timestamp": "2024-02-12T19:38:32.068596"
+    }
+}

--- a/modules/nf-core/samtools/view/tests/tags.yml
+++ b/modules/nf-core/samtools/view/tests/tags.yml
@@ -1,0 +1,2 @@
+samtools/view:
+  - "modules/nf-core/samtools/view/**"

--- a/nextflow.config
+++ b/nextflow.config
@@ -109,7 +109,6 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.userEmulation   = true
         conda.enabled          = false
         singularity.enabled    = false
         podman.enabled         = false

--- a/subworkflows/local/alignment_to_fastq.nf
+++ b/subworkflows/local/alignment_to_fastq.nf
@@ -23,16 +23,16 @@ workflow ALIGNMENT_TO_FASTQ {
     // Index File if not PROVIDED -> this also requires updates to samtools view possibly URGH
 
     // MAP - MAP
-    SAMTOOLS_VIEW_MAP_MAP(input, fasta, [])
+    SAMTOOLS_VIEW_MAP_MAP(input, fasta.map{ it -> [[:], it] }, [])
 
     // UNMAP - UNMAP
-    SAMTOOLS_VIEW_UNMAP_UNMAP(input, fasta, [])
+    SAMTOOLS_VIEW_UNMAP_UNMAP(input, fasta.map{ it -> [[:], it] }, [])
 
     // UNMAP - MAP
-    SAMTOOLS_VIEW_UNMAP_MAP(input, fasta, [])
+    SAMTOOLS_VIEW_UNMAP_MAP(input, fasta.map{ it -> [[:], it] }, [])
 
     // MAP - UNMAP
-    SAMTOOLS_VIEW_MAP_UNMAP(input, fasta, [])
+    SAMTOOLS_VIEW_MAP_UNMAP(input, fasta.map{ it -> [[:], it] }, [])
 
     // Channel for merging UNMAPPED BAM
     all_unmapped_bam = SAMTOOLS_VIEW_UNMAP_UNMAP.out.bam
@@ -54,7 +54,7 @@ workflow ALIGNMENT_TO_FASTQ {
     ch_unmapped_bam_cram = Channel.empty().mix(all_unmapped_bam,all_unmapped_cram)
 
     // MERGE UNMAP
-    SAMTOOLS_MERGE_UNMAP(ch_unmapped_bam_cram, fasta, fasta_fai)
+    SAMTOOLS_MERGE_UNMAP(ch_unmapped_bam_cram, fasta.map{ it -> [[:], it] }, fasta_fai.map{ it -> [[:], it] })
 
     def interleave = false
 

--- a/subworkflows/local/pre_conversion_qc.nf
+++ b/subworkflows/local/pre_conversion_qc.nf
@@ -11,6 +11,7 @@ workflow PRE_CONVERSION_QC {
     take:
     input // channel: [meta, alignment (BAM or CRAM), index (optional)]
     fasta // optional: reference file if CRAM format and reference not in header
+    fasta_fai // optional: index for fasta
 
     main:
 
@@ -23,7 +24,7 @@ workflow PRE_CONVERSION_QC {
     SAMTOOLS_FLAGSTAT(input)
 
     // SAMTOOLS STATS
-    SAMTOOLS_STATS(input, fasta)
+    SAMTOOLS_STATS(input, fasta, fasta_fai)
 
     // FASTQC ONLY ON BAM
     input.branch{

--- a/subworkflows/local/pre_conversion_qc.nf
+++ b/subworkflows/local/pre_conversion_qc.nf
@@ -11,7 +11,6 @@ workflow PRE_CONVERSION_QC {
     take:
     input // channel: [meta, alignment (BAM or CRAM), index (optional)]
     fasta // optional: reference file if CRAM format and reference not in header
-    fasta_fai // optional: index for fasta
 
     main:
 
@@ -24,7 +23,7 @@ workflow PRE_CONVERSION_QC {
     SAMTOOLS_FLAGSTAT(input)
 
     // SAMTOOLS STATS
-    SAMTOOLS_STATS(input, fasta, fasta_fai)
+    SAMTOOLS_STATS(input, fasta.map{ it -> [[:], it] })
 
     // FASTQC ONLY ON BAM
     input.branch{

--- a/subworkflows/local/prepare_indices.nf
+++ b/subworkflows/local/prepare_indices.nf
@@ -43,7 +43,7 @@ workflow PREPARE_INDICES {
     // INDEX FASTA
     fasta_fai = Channel.empty()
     if(params.fasta && !params.fasta_fai){
-        SAMTOOLS_FAIDX(fasta.map{ it -> [[id:it[0].baseName], it] })
+        SAMTOOLS_FAIDX(fasta.map{ it -> [[id:it[0].baseName], it] }, [[:], []])
         ch_versions = ch_versions.mix(SAMTOOLS_FAIDX.out.versions)
         fasta_fai   = SAMTOOLS_FAIDX.out.fai.map{ meta, fai -> [fai] }
 

--- a/workflows/bamtofastq.nf
+++ b/workflows/bamtofastq.nf
@@ -111,7 +111,8 @@ workflow BAMTOFASTQ {
 
     PRE_CONVERSION_QC(
         ch_input,
-        fasta
+        fasta,
+        fasta_fai
     )
 
     ch_versions = ch_versions.mix(PRE_CONVERSION_QC.out.versions)

--- a/workflows/bamtofastq.nf
+++ b/workflows/bamtofastq.nf
@@ -103,7 +103,7 @@ workflow BAMTOFASTQ {
 
     ch_versions = ch_versions.mix(PREPARE_INDICES.out.versions)
 
-    fasta_fai = params.fasta ? params.fasta_fai ? Channel.fromPath(params.fasta_fai).collect() : PREPARE_INDICES.out.fasta_fai : []
+    fasta_fai = params.fasta ? params.fasta_fai ? Channel.fromPath(params.fasta_fai).collect() : PREPARE_INDICES.out.fasta_fai : Channel.value([])
 
     ch_input = PREPARE_INDICES.out.ch_input_indexed
 
@@ -111,8 +111,7 @@ workflow BAMTOFASTQ {
 
     PRE_CONVERSION_QC(
         ch_input,
-        fasta,
-        fasta_fai
+        fasta
     )
 
     ch_versions = ch_versions.mix(PRE_CONVERSION_QC.out.versions)
@@ -146,7 +145,7 @@ workflow BAMTOFASTQ {
     // Extract only reads mapping to a chromosome
     if (params.chr) {
 
-        SAMTOOLS_CHR(ch_input_new, fasta, [])
+        SAMTOOLS_CHR(ch_input_new, fasta.map{ it -> [[:], it] }, [])
 
         samtools_chr_out = Channel.empty().mix( SAMTOOLS_CHR.out.bam,
                                                 SAMTOOLS_CHR.out.cram)


### PR DESCRIPTION
Update samtools to v1.19.2.

Had to do some search-replace of `fasta` to `fasta.map{ it -> [[:], it] }` in calls to samtools-models. There might be a more elegant solution though.

Detail:  I got this warning: `WARN: Undocumented setting "docker.userEmulation" is not supported any more - please remove it from your config` so I removed `docker.userEmulation` from `nextflow.config`.

TO-DO: Update CHANGELOG.

